### PR TITLE
feat: Implements GET /lotteries?include=:number&include=:number2

### DIFF
--- a/cmd/http/handlers.go
+++ b/cmd/http/handlers.go
@@ -12,7 +12,17 @@ import (
 func getLotteries(repo domain.LotteryRepoitoy) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
-		lotteries, err := repo.FindAll()
+		strIncludes := r.URL.Query()["include"]
+		includes := make([]uint, len(strIncludes))
+		for i, s := range strIncludes {
+			n, err := strconv.Atoi(s)
+			if err != nil {
+				writeHttpErrorResponse(w, err)
+				return
+			}
+			includes[i] = uint(n)
+		}
+		lotteries, err := repo.FindAllByNumbers(includes...)
 		if err != nil {
 			writeHttpErrorResponse(w, err)
 			return

--- a/domain/lottery.go
+++ b/domain/lottery.go
@@ -1,10 +1,22 @@
 package domain
 
+import "slices"
+
 type Lottery struct {
 	Round      uint   `json:"round"`
 	PickedDate string `json:"date"`
 	Numbers    []uint `json:"numbers"`
 	Wins       []Win  `json:"wins"`
+}
+
+func (l Lottery) CotainsAll(numbers ...uint) bool {
+	for _, num := range numbers {
+		_, found := slices.BinarySearch(l.Numbers, num)
+		if !found {
+			return false
+		}
+	}
+	return true
 }
 
 type Win struct {
@@ -15,4 +27,5 @@ type Win struct {
 type LotteryRepoitoy interface {
 	FindAll() ([]Lottery, error)
 	FindByRound(round uint) (Lottery, error)
+	FindAllByNumbers(numbers ...uint) ([]Lottery, error)
 }

--- a/lottery/repository/sqlite/repository.go
+++ b/lottery/repository/sqlite/repository.go
@@ -11,7 +11,7 @@ type LotteryRepoitoy struct {
 	db *sql.DB
 }
 
-func NewLotteryRepository(db *sql.DB) *LotteryRepoitoy {
+func NewLotteryRepository(db *sql.DB) domain.LotteryRepoitoy {
 	return &LotteryRepoitoy{db}
 }
 
@@ -59,6 +59,24 @@ func (repo *LotteryRepoitoy) FindByRound(round uint) (domain.Lottery, error) {
 		return domain.Lottery{}, err
 	}
 	return r.toLottery(), nil
+}
+
+func (repo *LotteryRepoitoy) FindAllByNumbers(numbers ...uint) ([]domain.Lottery, error) {
+	if len(numbers) == 0 {
+		return repo.FindAll()
+	}
+	lotteries, err := repo.FindAll()
+	if err != nil {
+		return nil, err
+	}
+
+	results := make([]domain.Lottery, 0)
+	for _, lottery := range lotteries {
+		if lottery.CotainsAll(numbers...) {
+			results = append(results, lottery)
+		}
+	}
+	return results, nil
 }
 
 type lotteryRow struct {

--- a/lottery/repository/sqlite/repository_test.go
+++ b/lottery/repository/sqlite/repository_test.go
@@ -47,4 +47,20 @@ func TestLotteryRepository(t *testing.T) {
 		}
 	})
 
+	t.Run("FindAllByNumbers", func(t *testing.T) {
+		for _, number := range []uint{10, 20, 30, 40} {
+			lotteries, err := repository.FindAllByNumbers(number)
+			assert.NoError(t, err)
+			assert.Positive(t, len(lotteries))
+		}
+
+		lotteries, err := repository.FindAllByNumbers(10, 20, 30)
+		assert.NoError(t, err)
+		assert.Positive(t, len(lotteries))
+
+		lotteries, err = repository.FindAllByNumbers(0, 10)
+		assert.NoError(t, err)
+		assert.Equals(t, len(lotteries), 0)
+	})
+
 }


### PR DESCRIPTION
## request sample
```sh
curl --location 'http://localhost:8080/lotteries?include=1&include=4'
```

## response
```json
[
    {
        "round": 1019,
        "date": "2022-06-11",
        "numbers": [
            1,
            4,
            13,
            17,
            34,
            6
        ],
        "wins": [
            {
                "num_winners": 50,
                "prize": 438565140
            },
            {
                "num_winners": 75,
                "prize": 48729460
            },
            {
                "num_winners": 5823,
                "prize": 627634
            },
            {
                "num_winners": 192646,
                "prize": 50000
            },
            {
                "num_winners": 2506493,
                "prize": 5000
            }
        ]
    },
    {
        "round": 1003,
        "date": "2022-02-19",
        "numbers": [
            1,
            4,
            29,
            39,
            43,
            31
        ],
        "wins": [
            {
                "num_winners": 14,
                "prize": 1811116822
            },
            {
                "num_winners": 66,
                "prize": 64029383
            },
            {
                "num_winners": 2649,
                "prize": 1595297
            },
            {
                "num_winners": 133896,
                "prize": 50000
            },
            {
                "num_winners": 2247475,
                "prize": 5000
            }
        ]
    }
]
```